### PR TITLE
Bug Fix Deck ID returning null

### DIFF
--- a/resources/decks/controller.js
+++ b/resources/decks/controller.js
@@ -39,16 +39,18 @@ exports.addDeck = async (req, res) => {
   };
   try {
     const deck = await Decks.add(newDeck);
-    await Promise.all(
-      tags.map(async tag => {
-        try {
-          const newDeckTag = { deck_id: deck.id, tag_id: tag };
-          Decks.addDeckTag(newDeckTag);
-        } catch (error) {
-          res.status(500).json({ message: `Error adding tag: ${tag}` });
-        }
-      })
-    );
+    if (tags) {
+      await Promise.all(
+        tags.map(async tag => {
+          try {
+            const newDeckTag = { deck_id: deck.id, tag_id: tag };
+            Decks.addDeckTag(newDeckTag);
+          } catch (error) {
+            res.status(500).json({ message: `Error adding tag: ${tag}` });
+          }
+        })
+      );
+    }
     res.status(201).json({ deck });
   } catch (error) {
     res.status(500).json({ message: `Error adding deck: ${error}` });

--- a/resources/decks/model.js
+++ b/resources/decks/model.js
@@ -5,7 +5,7 @@ exports.getAll = () => {
     .rightJoin('decks as d', 'd.id', 'dt.deck_id')
     .leftJoin('tags as t', 't.id', 'dt.tag_id')
     .select(
-      'dt.deck_id',
+      'd.id as deck_id',
       'd.user_id',
       'd.name as deck_name',
       'd.public',
@@ -14,7 +14,7 @@ exports.getAll = () => {
       db.raw('ARRAY_AGG( DISTINCT t.name) as tags')
     )
     .groupBy(
-      'dt.deck_id',
+      'd.id',
       'd.user_id',
       'd.name',
       'd.public',
@@ -29,7 +29,7 @@ exports.getUserDecks = userId => {
     .rightJoin('decks as d', 'd.id', 'dt.deck_id')
     .leftJoin('tags as t', 't.id', 'dt.tag_id')
     .select(
-      'dt.deck_id',
+      'd.id as deck_id',
       'd.user_id',
       'd.name as deck_name',
       'd.public',
@@ -38,7 +38,7 @@ exports.getUserDecks = userId => {
       db.raw('ARRAY_AGG( DISTINCT t.name) as tags')
     )
     .groupBy(
-      'dt.deck_id',
+      'd.id',
       'd.user_id',
       'd.name',
       'd.public',
@@ -61,7 +61,7 @@ exports.findById = id => {
     .leftJoin('tags as t', 't.id', 'dt.tag_id')
     .leftJoin('flashcards as f', 'f.deck_id', 'dt.deck_id')
     .select(
-      'dt.deck_id',
+      'd.id as deck_id',
       'd.user_id',
       'd.name as deck_name',
       'd.public',
@@ -71,7 +71,7 @@ exports.findById = id => {
       db.raw('array_to_json(ARRAY_AGG( DISTINCT f)) as flashcards')
     )
     .groupBy(
-      'dt.deck_id',
+      'd.id',
       'd.user_id',
       'd.name',
       'd.public',


### PR DESCRIPTION
# Description

Made deck id the called on the right side of the right join so it can never be null.
Enabled in the tags in create a deck to be truly unrequired and add a conditional to prevent error unable to map undefined

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works .
- [x] New and existing unit tests pass locally with my changes
