### PR TITLE
Fix Add Deck Name to Session by ID

### DIFF
--- a/resources/sessions/middleware.js
+++ b/resources/sessions/middleware.js
@@ -6,7 +6,7 @@ const {
 const { getCardById } = require('../flashcards/model');
 const { findById } = require('../decks/model');
 
-exports.sesssionExists = async (req, res, next) => {
+exports.sessionExists = async (req, res, next) => {
   const { id } = req.params;
   try {
     const sessionExists = await findSessionById(id);

--- a/resources/sessions/model.js
+++ b/resources/sessions/model.js
@@ -13,16 +13,25 @@ exports.findSessionById = id => {
   return db('sessions as s')
     .leftJoin('sessions_tracker as st', 'st.session_id', 's.id')
     .leftJoin('flashcards as f', 'f.deck_id', 's.deck_id')
+    .leftJoin('decks as d', 'd.id', 's.deck_id')
     .select(
       's.id',
       's.deck_id',
       's.user_id',
       's.isCompleted',
       's.last_used',
+      'd.name',
       db.raw('array_to_json(ARRAY_AGG( DISTINCT st)) as reviewed_cards'),
       db.raw('array_to_json(ARRAY_AGG( DISTINCT f)) as flashcards')
     )
-    .groupBy('s.id', 's.deck_id', 's.user_id', 's.isCompleted', 's.last_used')
+    .groupBy(
+      's.id',
+      's.deck_id',
+      's.user_id',
+      's.isCompleted',
+      's.last_used',
+      'd.name'
+    )
     .where({ 's.id': id })
     .first();
 };

--- a/resources/sessions/router.js
+++ b/resources/sessions/router.js
@@ -12,7 +12,7 @@ const {
   cardExists,
   deckExists,
   cardAlreadyMarked,
-  sesssionExists,
+  sessionExists,
   cardBelongsToDeck,
   preventDuplicateIncompleteSessions,
 } = require('./middleware');
@@ -28,17 +28,17 @@ sessionRouter.post(
   makeSession
 );
 
-sessionRouter.get('/:id', sesssionExists, fetchSessionById);
+sessionRouter.get('/:id', sessionExists, fetchSessionById);
 
 sessionRouter.put(
   '/:id',
-  sesssionExists,
+  sessionExists,
   cardExists,
   cardAlreadyMarked,
   cardBelongsToDeck,
   modifySession
 );
 
-sessionRouter.delete('/:id', sesssionExists, removeSession);
+sessionRouter.delete('/:id', sessionExists, removeSession);
 
 module.exports = sessionRouter;


### PR DESCRIPTION
# Description
- Add `Deck Name` to the current session that is returned when fetched by id

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
